### PR TITLE
Return express server

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ RestberryExpress.prototype.get = function() {
 };
 
 RestberryExpress.prototype.listen = function(port, next) {
-    this.app.listen(port, next);
+    return this.app.listen(port, next);
 };
 
 RestberryExpress.prototype.post = function() {


### PR DESCRIPTION
We can handle express server to use with other libraries. Socket.io, for example. requires it.

Example

``` ts

let server = Restberry
  .config({
    apiPath: '/api/v1',
    env: 'prod',
    name: 'WEATHER APP',
    port: 3000,
  })
  .use('express')
  .use('mongoose', function (odm) {
    odm.connect('mongodb://localhost:27017/local');
  });

let io = socket.listen(server.listen());

```
